### PR TITLE
Add filenamePattern option in negative-tests

### DIFF
--- a/src/rules/negativeTests.js
+++ b/src/rules/negativeTests.js
@@ -3,12 +3,16 @@ export default {
     const options = context.options[0];
     let minTests = 3;
     let errorIndicator = '$ExpectError';
+    let filenamePattern;
     if (typeof options === 'object') {
       if (options.hasOwnProperty('minTests') && typeof options.minTests === 'number') {
         minTests = options.minTests;
       }
       if (options.hasOwnProperty('errorIndicator') && typeof options.errorIndicator === 'string') {
         errorIndicator = options.errorIndicator;
+      }
+      if (options.hasOwnProperty('filenamePattern') && typeof options.filenamePattern === 'string') {
+        filenamePattern = new RegExp(options.filenamePattern);
       }
     }
 
@@ -22,7 +26,7 @@ export default {
       'Program:exit'() {
         const comments = context.getAllComments();
         const expectErrorCount = comments.filter(c => c.value.trim().startsWith(errorIndicator)).length;
-        if (expectErrorCount < minTests) {
+        if (expectErrorCount < minTests && (!filenamePattern || context.getFilename().match(filenamePattern))) {
           context.report({
             loc: { line: 1, column: 0 },
             message: `Test has to include at least ${minTests} negative Tests.`,

--- a/test/rules/negativeTests.js
+++ b/test/rules/negativeTests.js
@@ -43,6 +43,14 @@ ruleTester.run('flow-typed/negative-tests', negativeTestRule, {
         errorIndicator: '$ErrorExpected',
       }],
     },
+    {
+      code: 'foo();',
+      filename: 'foo/bar.js',
+      options: [{
+        minTests: 1,
+        filenamePattern: 'test',
+      }],
+    },
   ],
   invalid: [
     {
@@ -81,6 +89,16 @@ ruleTester.run('flow-typed/negative-tests', negativeTestRule, {
       options: [2],
       errors: [{
         message: 'Test has to include at least 2 negative Tests.',
+      }],
+    }, {
+      code: 'foo();',
+      filename: 'foo/bar_test.js',
+      options: [{
+        minTests: 1,
+        filenamePattern: 'test',
+      }],
+      errors: [{
+        message: 'Test has to include at least 1 negative Tests.',
       }],
     },
   ],


### PR DESCRIPTION
With this option it would be possible to only activate the lint rule on
test files in the flow-typed repo.
